### PR TITLE
Add GitHub Actions workflow to build project

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Build and Output Executable
+
+on:
+  push:
+    branches:
+      - feat-gh-action-build
+  pull_request:
+    branches:
+      - feat-gh-action-build
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Xcode
+        run: sudo xcode-select -s /Applications/Xcode_12.5.app
+
+      - name: Install dependencies
+        run: |
+          sudo gem install cocoapods
+          pod install
+
+      - name: Build project
+        run: xcodebuild -project IpInfo.xcodeproj -scheme IpInfo -configuration Release
+
+      - name: Save executable
+        uses: actions/upload-artifact@v2
+        with:
+          name: IpInfo
+          path: IpInfo/output/IpInfo.app

--- a/IpInfo.xcodeproj/project.pbxproj
+++ b/IpInfo.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 				B2C95D1128009E8600CDE681 /* Sources */,
 				B2C95D1228009E8600CDE681 /* Frameworks */,
 				B2C95D1328009E8600CDE681 /* Resources */,
+				B2C95D372800B31400CDE681 /* Copy Executable */,
 			);
 			buildRules = (
 			);
@@ -177,6 +178,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		B2C95D372800B31400CDE681 /* Copy Executable */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Executable";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "cp -r \"${BUILT_PRODUCTS_DIR}/${FULL_PRODUCT_NAME}\" \"${PROJECT_DIR}/output/\"";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
 		B2C95D2228009E8B00CDE681 /* Debug */ = {


### PR DESCRIPTION
Add GitHub Actions workflow to build the project and output the executable.

* **IpInfo.xcodeproj/project.pbxproj**
  - Add a new build phase to copy the built executable to the output directory.
  - Update the build settings to include the new build phase.

* **.github/workflows/build.yml**
  - Create a new GitHub Actions workflow file.
  - Set up the macOS environment and install dependencies.
  - Build the project using Xcode.
  - Save the built executable as an artifact.

## Summary by Sourcery

CI:
- Add a GitHub Actions workflow to build the project on macOS and save the executable as an artifact.